### PR TITLE
feat: add KubeStellar Console

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [Coroot](https://coroot.com) - Open source observability with AI-powered root cause analysis and eBPF-based auto-instrumentation.
 - [Last9](https://last9.io) - Unified observability with Agentic SRE SDK, AI copilot integration with Claude, Cursor, and Slack, and managed TSDB.
 - [SigNoz](https://signoz.io) - Open source OpenTelemetry-native observability platform for logs, metrics, and traces with unified correlation analysis.
+- [KubeStellar Console](https://console.kubestellar.io) - Open source AI-powered multi-cluster Kubernetes dashboard with AI-guided operations, real-time observability across hybrid and edge clusters, and 20+ CNCF integrations (Prometheus, Grafana, Falco, Kyverno, OPA/Gatekeeper). CNCF Sandbox project.
 
 ## AIOps Platforms
 


### PR DESCRIPTION
## Summary

Adds [KubeStellar Console](https://github.com/kubestellar/console) to the **LLM-Powered DevOps Tools** section.

KubeStellar Console is an open source AI-powered multi-cluster Kubernetes dashboard with:
- AI chat interface for cluster troubleshooting and autonomous SRE operations
- Real-time observability across hybrid edge and cloud environments
- 20+ CNCF integrations (Argo, Kyverno, Prometheus, Grafana, Istio, Flux, Falco)
- Mission-based autonomous operations and AI-guided remediation

It is a CNCF Sandbox project licensed under Apache 2.0.

- GitHub: https://github.com/kubestellar/console
- Live: https://console.kubestellar.io