### PR TITLE
Add Regen — open-source self-hosted incident management

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
 - [Squadcast](https://squadcast.com) - Incident management with AI-driven alert clustering and automatic grouping of related incidents. Acquired by SolarWinds.
 - [Zenduty](https://zenduty.com) - On-call and incident management with AI Summarizer, AI Postmortem, and AI Scheduling. Acquired by Xurrent, rebranding to Xurrent IMR.
 - [BetterStack](https://betterstack.com) - Developer-friendly uptime monitoring and incident management with integrated observability.
+- [Regen](https://github.com/FluidifyAI/Regen) - Open-source, self-hosted incident management with agent-native architecture, BYO AI for summaries and post-mortems, on-call scheduling, and Slack/Teams integration. AGPLv3.
 
 ## Observability Platforms
 


### PR DESCRIPTION
## Add Regen

**Regen** is an open-source, self-hosted incident management platform built with an agent-native architecture — the first OSS incident platform where AI agents and humans operate on the same identity model, permissions, and timeline.

**Why it fits here:**
- Agent-native by design: AI agents are first-class actors, not a feature layer
- BYO OpenAI key for incident summaries, post-mortem drafts, and historical pattern matching
- MCP server (beta) — Claude, GPT, and custom bots can call Regen to open incidents, add timeline entries, query history
- Self-hosted alternative to PagerDuty / Grafana OnCall (archived March 2026)

**Links:**
- GitHub: https://github.com/FluidifyAI/Regen
- License: AGPLv3
- Stack: Go + React, Docker Compose + Kubernetes Helm