### PR TITLE
feat: add TWZRD Agent Intel to Observability Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
 - [Last9](https://last9.io) - Unified observability with Agentic SRE SDK, AI copilot integration with Claude, Cursor, and Slack, and managed TSDB.
 - [SigNoz](https://signoz.io) - Open source OpenTelemetry-native observability platform for logs, metrics, and traces with unified correlation analysis.
 - [Metoro](https://metoro.io/) - Kubernetes native observability platform with built-in eBPF telemetry, AI investigation, deployment verification and root-cause analysis.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Agent wallet trust scoring for multi-agent observability pipelines. Verify which AI agent is calling before billing, logging, or granting production access — free MCP server with `score_agent(wallet)` and `preflight_check(wallet)` tools.
 
 ## AIOps Platforms
 


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the Observability Platforms section.

In multi-agent SRE systems, knowing *which* agent triggered an action is critical for audit trails and accountability. TWZRD Agent Intel provides agent wallet trust scoring — verify AI agent identity before granting production access, logging agent actions, or billing agent activity.

- **Free tools**: `score_agent(wallet)`, `preflight_check(wallet)` via MCP
- **MCP config**: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
- **Trust receipts**: paid `get_trust_receipt(wallet)` via x402 micropayment for audit-grade verification