### PR TITLE
Add Radar to Observability Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@
 - [Last9](https://last9.io) - Unified observability with Agentic SRE SDK, AI copilot integration with Claude, Cursor, and Slack, and managed TSDB.
 - [SigNoz](https://signoz.io) - Open source OpenTelemetry-native observability platform for logs, metrics, and traces with unified correlation analysis.
 - [Metoro](https://metoro.io/) - Kubernetes native observability platform with built-in eBPF telemetry, AI investigation, deployment verification and root-cause analysis.
+- [Radar](https://github.com/skyhook-io/radar) - Open source Kubernetes observability with topology, service traffic, and event timeline, plus a built-in MCP server and a 31-check best-practices audit for AI assistants.
 
 ## AIOps Platforms
 


### PR DESCRIPTION
Adds [Radar](https://github.com/skyhook-io/radar) to the Observability Platforms section.

Radar is an open source (Apache-2.0) Kubernetes observability tool — topology, service traffic, and an event timeline, with a built-in MCP server that lets AI assistants (Claude, Cursor, Copilot) query cluster state, plus a 31-check best-practices audit.

Meets the inclusion criteria:
- Open source with 2.4k+ stars (well above the 50-star threshold)
- Actively maintained (latest release v1.7.7, June 2026)
- Relevant to AI-powered SRE via its built-in MCP server

Placed alongside the other open-source Kubernetes-native observability tools (Coroot, SigNoz, Metoro). One sentence, ending with a period, per the format.