### PR TITLE
Add Aurora to AI SRE Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 - [Nudge Bee](https://nudgebee.com) - Enterprise AI-agentic workflow platform for SRE and CloudOps with pre-built AI assistants and customizable workflows.
 - [Agent SRE](https://agentsre.ai) - AI agent for autonomous site reliability engineering.
 - [Anyshift](https://anyshift.io) - AI SRE agent that investigates production incidents by tracing changes across a versioned infrastructure graph to identify root causes.
+- [Aurora](https://github.com/Arvo-AI/aurora) - Open-source (Apache 2.0) AI SRE agent that autonomously investigates incidents and delivers root cause analysis across AWS, Azure, GCP, and Kubernetes, with bring-your-own-LLM support including local models via Ollama.
 - [Guardian by Metoro](https://metoro.io/ai-sre-agent) - AI SRE agent for Kubernetes that detects issues, finds the root cause, and opens fix PRs automatically.
 - [Hyground](https://hyground.ai) - A sovereign AI SRE agent built to operate complex software across your entire stack, automatically find root causes and cut DevOps toil.
 


### PR DESCRIPTION
Adds Aurora to the AI SRE Agents category.

Aurora is an open-source (Apache 2.0) AI SRE agent that autonomously investigates incidents: it queries cloud provider APIs directly, runs CLI commands (kubectl, aws, az, gcloud) in sandboxed Kubernetes pods, and synthesizes findings into a root cause analysis. Multi-cloud (AWS, Azure, GCP, OVH, Scaleway, Cloudflare, Kubernetes), self-hosted, and works with major LLM providers or local models via Ollama.

Guidelines check: actively maintained (last commit this week), 350+ GitHub stars, Apache-2.0 license, one entry with a one-sentence description ending in a period, placed with the other A- entries.

Disclosure: I'm a co-founder at Arvo AI, the company behind Aurora.