### PR TITLE
Add Aient AI to AI SRE Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 - [Anyshift](https://anyshift.io) - AI SRE agent that investigates production incidents by tracing changes across a versioned infrastructure graph to identify root causes.
 - [Guardian by Metoro](https://metoro.io/ai-sre-agent) - AI SRE agent for Kubernetes that detects issues, finds the root cause, and opens fix PRs automatically.
 - [Hyground](https://hyground.ai) - A sovereign AI SRE agent built to operate complex software across your entire stack, automatically find root causes and cut DevOps toil.
+- [Aient AI](https://aient.ai) - OpenTelemetry-native AI SRE agent that groups errors from logs, metrics, and traces into problems, investigates root cause, and opens a GitHub pull request with a fix for human review.
 
 ## AI Production Debugging
 


### PR DESCRIPTION
Adds **Aient AI** ([aient.ai](https://aient.ai)) to the **AI SRE Agents** section.

**Disclosure:** I work on Aient AI (Triple Alpha AB) — this is a vendor/maintainer self-submission.

### What it is
Aient AI is an OpenTelemetry-native AI SRE agent. It ingests logs, metrics, and traces (OTLP), groups errors into "problems," runs an AI agent that investigates root cause and opens a **GitHub pull request** with a proposed fix, then watches production telemetry to check whether the problem stops recurring. The pull request is the human approval gate — Aient does not merge or deploy to production itself. It also exposes a hosted, OAuth-gated MCP server (problems/telemetry/remediation tools) and integrates with GitHub, Slack, Linear, Vercel, and AWS CloudWatch/Firehose.

- Homepage: https://aient.ai
- Docs: https://docs.aient.ai
- Status: commercial, early-access, closed-source.

### Entry
```
- [Aient AI](https://aient.ai) - OpenTelemetry-native AI SRE agent that groups errors from logs, metrics, and traces into problems, investigates root cause, and opens a GitHub pull request with a fix for human review.
```

### Notes
- One entry, one file (`README.md`). Placed at the bottom of **AI SRE Agents** (the section is not alphabetized, so I followed its existing append order — happy to reorder if you prefer).
- Matches the sections bullet format: homepage link, single sentence ending with a period.
- `awesome-lint` reports only two pre-existing issues (the malformed `- -` Middleware OpsAI line and the fork git-remote check); my line adds no new lint errors.
- Fits alongside comparable "opens fix PRs" agents already listed (Guardian by Metoro, Middleware OpsAI).