### PR TITLE
Add Loop & Retry to Blogs and Newsletters

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@
 - [NeuBird Blog](https://neubird.ai/blog) - GenAI SRE predictions and industry analysis.
 - [Metoro Blog](https://metoro.io/blog) - Observability, AI SRE and Kubernetes content.
 - [Hyground Blog](https://hyground.ai/blog) - AI SRE, observability, GenAI / security content.
+- [What to Actually Measure When Your Agent "Works"](https://loopandretry.github.io/posts/what-to-measure-when-your-agent-works/?ref=awesome-ai-sre) - A five-layer scheme (outcome, trajectory, cost, failure class, stability) for grading an agent beyond its final answer.
 
 ## Community Lists
 


### PR DESCRIPTION
Adds one practitioner post to Blogs and Newsletters.

Link: https://loopandretry.github.io/posts/what-to-measure-when-your-agent-works/

Why it fits: a concrete measurement scheme for agent reliability in production — the same practical-ops lane as the other blogs listed here.

Disclosure: I write this blog; submitting because it's on-topic for AI SRE, not as a marketing page.