### PR TITLE
Add Hyperping to Incident Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@
 - [incident.io](https://incident.io) - Slack-native incident management with AI SRE, AI alert triage, AI postmortems, Scribe call transcription, and Claude and Cursor integration.
 - [Rootly](https://rootly.com) - AI-native incident management with LLM-powered investigation across the observability stack.
 - [FireHydrant](https://firehydrant.com) - AI-powered incident summaries, Zoom-aware context enrichment, and AI-drafted retrospectives. Being acquired by Freshworks.
+- [Hyperping](https://hyperping.com) - Uptime, API, and server monitoring with on-call scheduling and status pages, exposed to AI agents through a remote MCP server covering monitors, outages, MTTR/MTTA reporting, and on-call schedules.
 - [Squadcast](https://squadcast.com) - Incident management with AI-driven alert clustering and automatic grouping of related incidents. Acquired by SolarWinds.
 - [Zenduty](https://zenduty.com) - On-call and incident management with AI Summarizer, AI Postmortem, and AI Scheduling. Acquired by Xurrent, rebranding to Xurrent IMR.
 - [BetterStack](https://betterstack.com) - Developer-friendly uptime monitoring and incident management with integrated observability.


### PR DESCRIPTION
Adds [Hyperping](https://hyperping.com) to **Incident Management**.

Uptime, API, cron and server monitoring with on-call schedules, escalation policies and status pages. The AI-SRE relevance is its remote MCP server ([docs](https://hyperping.com/docs/mcp)): 26 tools (22 read, 4 write) that let an agent list and create monitors, pull outages and timelines, query uptime, response time, MTTR and MTTA, and resolve who is on call through escalation policies and schedules. Same category as the MCP server integration already noted on the PagerDuty AIOps entry.

**On the guidelines:** description is a single sentence ending with a period. The section is not currently in alphabetical order, so I placed the entry where it would fall alphabetically (after FireHydrant, before incident.io). Happy to move it wherever you prefer.

**Quality standards:** commercial product, public website, public docs and status page, actively maintained.